### PR TITLE
fix: 카드 컴포넌트에서 터치 영역 관련 버그 수정

### DIFF
--- a/Projects/Shared/DesignSystem/Sources/Components/Card/Goal/GoalCardView.swift
+++ b/Projects/Shared/DesignSystem/Sources/Components/Card/Goal/GoalCardView.swift
@@ -183,12 +183,15 @@ private extension GoalCardView {
                     .resizable()
                     .placeholder { }
                     .scaledToFill()
+                    .frame(minWidth: 0, maxWidth: .infinity)
+                    .frame(height: config.imageHeight)
+                    .clipped()
             } else {
                 unCompletedView(placeholder: placeholder, buttonAction: buttonAction)
+                    .frame(minWidth: 0, maxWidth: .infinity)
+                    .frame(height: config.imageHeight)
             }
         }
-        .frame(minWidth: 0, maxWidth: .infinity)
-        .frame(height: config.imageHeight)
         .clipShape(unEvenRoundedRect)
         .contentShape(Rectangle())
         .overlay(alignment: .bottomTrailing) {


### PR DESCRIPTION
<!--
PR 제목 작성 가이드: 
라벨명: 작업한 내용 요약
예: feat: 로그인 페이지 구현
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (자동으로 Close 처리됨) -->
- Close #184 


## 📙 작업 내역
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요(구현 내용 및 작업 내역을 기재합니다.) -->
- 이미지의 실제 크기가 자신의 영역보다 더 큰데, 이 이미지가 Hierachy상 남아서 터치 영역을 뺏는 버그 수정
  - 프레임을 별도로 잡고, 클립하여 터치 영역이 자신의 영역을 침범하지 않도록 수정


## 🎨 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
https://github.com/user-attachments/assets/925a5c1d-04e1-4401-af73-63f9ec1cbdd5