### PR TITLE
feat: 커플 연결 과정에서의 사용성 개선

### DIFF
--- a/Projects/App/Sources/Reducer/AppCoordinator.swift
+++ b/Projects/App/Sources/Reducer/AppCoordinator.swift
@@ -212,14 +212,22 @@ struct AppCoordinator {
                 return .send(.route(.mainTab(.notificationDeepLinkReceived(deepLink))))
 
             case .route(.auth(.delegate(.loginSucceeded))):
-                return .run { [onboardingClient] send in
-                    do {
-                        let status = try await onboardingClient.fetchStatus()
-                        await send(.checkOnboardingStatusResult(.success(status)))
-                    } catch {
-                        await send(.checkOnboardingStatusResult(.failure(error)))
-                    }
-                }
+                return .merge(
+                    // 1. 온보딩 상태 체크
+                    .run { [onboardingClient] send in
+                        do {
+                            let status = try await onboardingClient.fetchStatus()
+                            await send(.checkOnboardingStatusResult(.success(status)))
+                        } catch {
+                            await send(.checkOnboardingStatusResult(.failure(error)))
+                        }
+                    },
+                    // 2. FCM 토큰 조기 등록 (온보딩 중 푸시 수신을 위해)
+                    registerFCMTokenEffect(
+                        pushClient: pushClient,
+                        notificationClient: notificationClient
+                    )
+                )
 
             case let .route(.onboarding(.delegate(.onboardingCompleted(isPushEnabled, isMarketingEnabled, isNightEnabled)))):
                 state.route = .mainTab(MainTabReducer.State())
@@ -303,13 +311,8 @@ private func registerFCMTokenEffect(
         // 1. 현재 권한 상태 확인
         let settings = await UNUserNotificationCenter.current().notificationSettings()
 
-        // 2. 권한이 없으면 요청
-        if settings.authorizationStatus == .notDetermined {
-            let granted = (try? await pushClient.requestAuthorization()) ?? false
-            if !granted { return }
-        } else if settings.authorizationStatus == .denied {
-            return
-        }
+        // 이미 권한이 허용된 경우에만 등록 (notDetermined/denied는 온보딩 완료 시점에서 처리)
+        guard settings.authorizationStatus == .authorized else { return }
 
         // 3. APNS 등록 및 FCM 토큰 획득
         await pushClient.registerForRemoteNotifications()

--- a/Projects/Feature/Onboarding/Sources/Connect/OnboardingConnectReducer.swift
+++ b/Projects/Feature/Onboarding/Sources/Connect/OnboardingConnectReducer.swift
@@ -6,6 +6,7 @@
 //
 
 import ComposableArchitecture
+import DomainOnboardingInterface
 import Foundation
 
 /// 커플 연결 온보딩 화면을 관리하는 Reducer입니다.
@@ -21,6 +22,9 @@ import Foundation
 /// ```
 @Reducer
 public struct OnboardingConnectReducer {
+    @Dependency(\.onboardingClient)
+    private var onboardingClient
+
     @ObservableState
     public struct State: Equatable {
         var isShareSheetPresented: Bool = false

--- a/Projects/Feature/Onboarding/Sources/OnboardingCoordinator.swift
+++ b/Projects/Feature/Onboarding/Sources/OnboardingCoordinator.swift
@@ -28,6 +28,12 @@ public struct OnboardingCoordinator {
     private var onboardingClient
     @Dependency(\.pushClient)
     private var pushClient
+    @Dependency(\.continuousClock)
+    private var clock
+
+    private enum CancelID {
+        case couplePolling
+    }
 
     @ObservableState
     public struct State: Equatable {
@@ -40,6 +46,7 @@ public struct OnboardingCoordinator {
         var pendingReceivedCode: String?
         var isLoadingInviteCode: Bool = false
         var initialStatus: OnboardingStatus
+        var isCouplePolling: Bool = false
 
         // MARK: - Notification Permission
         var isNotificationModalPresented: Bool = false
@@ -93,6 +100,12 @@ public struct OnboardingCoordinator {
         // MARK: - Navigation
         case navigateToCodeInputWithCode(myInviteCode: String, receivedCode: String)
 
+        // MARK: - Couple Polling (커플 연결 대기 중 상태 확인)
+        case startCouplePolling
+        case stopCouplePolling
+        case couplePollingTick
+        case couplePollingResult(Result<OnboardingStatus, Error>)
+
         // MARK: - Deep Link
         case deepLinkReceived(code: String)
 
@@ -133,27 +146,76 @@ public struct OnboardingCoordinator {
 
             // MARK: - LifeCycle
             case .onAppear:
+                // 커플 연결 단계가 아니면 폴링 불필요
+                guard state.initialStatus == .coupleConnection else { return .none }
+
+                var effects: [Effect<Action>] = [.send(.startCouplePolling)]
+
                 // 초대 코드가 비어있으면 API 호출
                 if state.myInviteCode.isEmpty {
                     state.isLoadingInviteCode = true
-                    return .run { send in
+                    effects.append(.run { send in
                         do {
                             let inviteCode = try await onboardingClient.fetchInviteCode()
                             await send(.fetchInviteCodeResponse(.success(inviteCode)))
                         } catch {
                             await send(.fetchInviteCodeResponse(.failure(error)))
                         }
-                    }
+                    })
                 }
 
                 // 딥링크로 받은 코드가 있으면 CodeInput으로 이동
                 if let code = state.pendingReceivedCode {
                     state.pendingReceivedCode = nil
-                    return .send(.navigateToCodeInputWithCode(
+                    effects.append(.send(.navigateToCodeInputWithCode(
                         myInviteCode: state.myInviteCode,
                         receivedCode: code
-                    ))
+                    )))
                 }
+
+                return .merge(effects)
+
+            // MARK: - Couple Polling
+            case .startCouplePolling:
+                guard !state.isCouplePolling else { return .none }
+                state.isCouplePolling = true
+                return .run { [clock] send in
+                    for await _ in clock.timer(interval: .seconds(3)) {
+                        await send(.couplePollingTick)
+                    }
+                }
+                .cancellable(id: CancelID.couplePolling, cancelInFlight: true)
+
+            case .stopCouplePolling:
+                state.isCouplePolling = false
+                return .cancel(id: CancelID.couplePolling)
+
+            case .couplePollingTick:
+                return .run { [onboardingClient] send in
+                    do {
+                        let status = try await onboardingClient.fetchStatus()
+                        await send(.couplePollingResult(.success(status)))
+                    } catch {
+                        await send(.couplePollingResult(.failure(error)))
+                    }
+                }
+
+            case let .couplePollingResult(.success(status)):
+                switch status {
+                case .profileSetup, .anniversarySetup, .completed:
+                    // 상대방이 연결 완료 → 폴링 중단 후 Profile로 이동
+                    state.isCouplePolling = false
+                    state.profile = OnboardingProfileReducer.State()
+                    state.routes.removeAll(where: { $0 == .codeInput })
+                    state.routes.append(.profile)
+                    return .cancel(id: CancelID.couplePolling)
+
+                case .coupleConnection:
+                    return .none
+                }
+
+            case .couplePollingResult(.failure):
+                // 에러 발생 시 다음 틱에서 재시도
                 return .none
 
             // MARK: - API Response
@@ -203,7 +265,11 @@ public struct OnboardingCoordinator {
 
             // MARK: - Connect Delegate
             case .connect(.delegate(.logoutRequested)):
-                return .send(.delegate(.logoutRequested))
+                state.isCouplePolling = false
+                return .merge(
+                    .cancel(id: CancelID.couplePolling),
+                    .send(.delegate(.logoutRequested))
+                )
 
             case .connect(.delegate(.navigateToCodeInput)):
                 state.codeInput = OnboardingCodeInputReducer.State(
@@ -224,9 +290,11 @@ public struct OnboardingCoordinator {
                 return .none
 
             case .codeInput(.delegate(.coupleConnected)):
+                // 사용자가 직접 코드 입력으로 연결 → 폴링 중단 후 Profile로 이동
+                state.isCouplePolling = false
                 state.profile = OnboardingProfileReducer.State()
                 state.routes.append(.profile)
-                return .none
+                return .cancel(id: CancelID.couplePolling)
 
             case .codeInput:
                 return .none


### PR DESCRIPTION
<!--
PR 제목 작성 가이드: 
라벨명: 작업한 내용 요약
예: feat: 로그인 페이지 구현
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (자동으로 Close 처리됨) -->
- Close #219 


## 📙 작업 내역
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요(구현 내용 및 작업 내역을 기재합니다.) -->
- 서버에 FCM 토큰 제공하는 타이밍 조정
  - 로그인 성공 시점에서 "즉시" 조기적으로 FCM 토큰을 서버에 제공
- OnboardingReducer에서 폴링을 통한 지속적 연결 상태 체크 구현
  - 커플 연결 전 유저는 두 화면(ConnectView, CodeInputView)에 갖혀있으므로, 두 화면 모두 컨트롤 가능한 상위 Reducer에서 작업

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요. -->
- 현재 서버 상태에 따라 검증이 불가능하므로, 확인 이후 Merge
