### PR TITLE
fix: 초대장 문구 수정 및 버그 수정

### DIFF
--- a/Projects/App/Sources/View/TwixApp.swift
+++ b/Projects/App/Sources/View/TwixApp.swift
@@ -96,7 +96,9 @@ private extension TwixApp {
     /// 초대 코드 딥링크 파싱
     /// - URL 형식: twix://invite?code=xxx 또는 https://xxx/invite?code=xxx
     func parseInviteCode(from url: URL) -> String? {
-        guard url.path == "/invite" || url.path == "invite",
+        // twix://invite?code=xxx → host: "invite", path: ""
+        // https://host/invite?code=xxx → path: "/invite"
+        guard url.host == "invite" || url.path == "/invite",
               let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let code = components.queryItems?.first(where: { $0.name == "code" })?.value,
               !code.isEmpty else {

--- a/Projects/Feature/Onboarding/Example/Sources/OnboardingApp.swift
+++ b/Projects/Feature/Onboarding/Example/Sources/OnboardingApp.swift
@@ -43,10 +43,7 @@ struct OnboardingApp: App {
 // MARK: - Deep Link Parsing
 
 private func parseInviteCode(from url: URL) -> String? {
-    guard let deeplinkHost = Bundle.main.object(forInfoDictionaryKey: "DEEPLINK_HOST") as? String,
-          let host = url.host,
-          host.contains(deeplinkHost),
-          url.path == "/invite",
+    guard url.path == "/invite" || url.path == "invite",
           let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
           let code = components.queryItems?.first(where: { $0.name == "code" })?.value,
           !code.isEmpty else {

--- a/Projects/Feature/Onboarding/Sources/OnboardingCoordinator.swift
+++ b/Projects/Feature/Onboarding/Sources/OnboardingCoordinator.swift
@@ -164,8 +164,9 @@ public struct OnboardingCoordinator {
                     })
                 }
 
-                // 딥링크로 받은 코드가 있으면 CodeInput으로 이동
-                if let code = state.pendingReceivedCode {
+                // 딥링크로 받은 코드가 있고 내 초대 코드도 준비된 경우에만 이동
+                // myInviteCode가 비어있으면 fetchInviteCodeResponse에서 처리
+                if let code = state.pendingReceivedCode, !state.myInviteCode.isEmpty {
                     state.pendingReceivedCode = nil
                     effects.append(.send(.navigateToCodeInputWithCode(
                         myInviteCode: state.myInviteCode,
@@ -224,7 +225,16 @@ public struct OnboardingCoordinator {
                 state.myInviteCode = inviteCode
                 state.connect.myInviteCode = inviteCode
                 if let deeplinkHost = Bundle.main.object(forInfoDictionaryKey: "DEEPLINK_HOST") as? String {
-                    state.connect.shareContent = "https://\(deeplinkHost)/invite?code=\(inviteCode)"
+                    state.connect.shareContent = """
+                    [키피럽 함께 시작해요]
+                    함께 시작하고 일상 속 시너지를!
+
+                    1. '키피럽'을 설치해 주세요. [스토어 링크]
+                    2. 회원가입을 해 주세요.
+                    3. 아래 링크를 통해 연결하거나, 연결 코드를 메이트과 공유하세요!
+
+                    https://\(deeplinkHost)/invite?code=\(inviteCode)
+                    """
                 }
 
                 // 딥링크로 받은 코드가 있으면 CodeInput으로 이동
@@ -254,13 +264,18 @@ public struct OnboardingCoordinator {
             // MARK: - Deep Link
             case let .deepLinkReceived(code):
                 state.routes.removeAll()
-                state.codeInput = OnboardingCodeInputReducer.State(
-                    myInviteCode: state.myInviteCode,
-                    receivedCode: code
-                )
                 state.profile = nil
                 state.dday = nil
-                state.routes.append(.codeInput)
+
+                if state.myInviteCode.isEmpty {
+                    state.pendingReceivedCode = code
+                } else {
+                    state.codeInput = OnboardingCodeInputReducer.State(
+                        myInviteCode: state.myInviteCode,
+                        receivedCode: code
+                    )
+                    state.routes.append(.codeInput)
+                }
                 return .none
 
             // MARK: - Connect Delegate


### PR DESCRIPTION
<!--
PR 제목 작성 가이드: 
라벨명: 작업한 내용 요약
예: feat: 로그인 페이지 구현
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (자동으로 Close 처리됨) -->
- Close #245 


## 📙 작업 내역
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요(구현 내용 및 작업 내역을 기재합니다.) -->
- 기존 초대장이 제대로 동작하지 않아 [유니버설 페이지](https://keepiluv.jiyong.xyz/) 재작성
  - 일반적인 상황에서, 링크를 누르면 AASA에 의해 기대한 동작을 수행함
  - 하지만, 대부분 초대장을 주고받는건 SNS나 메신저 등으로 할 것으로 보이는데, 이 경우 문제가 있음
    - 카카오톡, 인스타그램 등의 앱은 링크를 바로 Safari에서 실행하는 게 아니라 내부 브라우저 또는 웹뷰로 실행함
    - 이에 따라 AASA가 동작하지 않는 문제가 있었으며, 해결
  - 기존 AASA는 그대로 동작하도록 두되, 유니버설 페이지에서 js로 User-Agent에 따라 분기처리 (fallback시 랜딩 페이지로)
- 앱 스킴 관련 수정
  - twix://invite가 동작하도록 스킴 파싱부 수정
  - 앱 스킴을 타고 코드 입력 화면에 진입하는 경우, 내 코드를 서버에서 받아오지 못하는 타이밍 이슈가 존재해 수정


## 🎨 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
### 앱 미설치의 경우 아래와 같이 동작함
https://github.com/user-attachments/assets/90e05f07-4c63-4a59-80d7-8251f509d317

*사용자 개입 없이 자연스럽게 앱스토어까지 보내짐*