### PR TITLE
fix: 종료된 목표에서 인증/찌르기를 방지하도록 수정

### DIFF
--- a/Projects/Feature/GoalDetail/Interface/Sources/GoalDetailReducer.swift
+++ b/Projects/Feature/GoalDetail/Interface/Sources/GoalDetailReducer.swift
@@ -77,6 +77,7 @@ public struct GoalDetailReducer {
         }
         public var comment: String { currentCard?.comment ?? "" }
         public var naviBarRightText: String {
+            guard currentCompletedGoal?.status != .completed else { return "" }
             if isFrontMyCard, isCompleted {
                 return isEditing ? "저장" : "수정"
             } else {
@@ -194,13 +195,13 @@ public struct GoalDetailReducer {
 extension GoalDetailReducer.State {
     public var emptyCardText: String {
         let isCompleted = currentCompletedGoal?.status == .completed
-        guard !isCompleted else { return "인증샷이 없어요" }
+        guard !isCompleted else { return "인증샷이\n없어요!" }
         
         if isFrontMyCard {
             return  "인증샷을\n올려보세요!"
         } else {
             guard let nickname = item?.partnerNickname else { return "" }
-            return "\(nickname)\n님은 아직인가봐요!"
+            return "\(nickname)님은\n아직..."
         }
     }
     

--- a/Projects/Feature/GoalDetail/Sources/Detail/GoalDetailReducer+Impl.swift
+++ b/Projects/Feature/GoalDetail/Sources/Detail/GoalDetailReducer+Impl.swift
@@ -16,6 +16,10 @@ import FeatureProofPhotoInterface
 import SharedDesignSystem
 import SharedUtil
 
+private enum PokeCancelID: Hashable {
+    case poke(Int64)
+}
+
 private enum PokeCooldownManager {
     private static let userDefaultsKey = "pokeCooldownTimestamps"
     private static let cooldownInterval: TimeInterval = 3 * 60 * 60
@@ -113,8 +117,8 @@ extension GoalDetailReducer {
                     let timeText = PokeCooldownManager.formatRemainingTime(remaining)
                     return .send(.showToast(.warning(message: "\(timeText) 뒤에 다시 찌를 수 있어요")))
                 }
-                PokeCooldownManager.recordPoke(goalId: goalId)
                 return .run { send in
+                    PokeCooldownManager.recordPoke(goalId: goalId)
                     do {
                         try await goalClient.pokePartner(goalId)
                         await send(.showToast(.poke(message: "상대방을 찔렀어요!")))
@@ -123,7 +127,8 @@ extension GoalDetailReducer {
                         await send(.showToast(.warning(message: "찌르기에 실패했어요")))
                     }
                 }
-                
+                .debounce(id: PokeCancelID.poke(goalId), for: .milliseconds(300), scheduler: DispatchQueue.main)
+
             case let .navigationBarTapped(action):
                 if case .backTapped = action {
                     return .send(.delegate(.navigateBack))

--- a/Projects/Feature/GoalDetail/Sources/Detail/GoalDetailReducer+Impl.swift
+++ b/Projects/Feature/GoalDetail/Sources/Detail/GoalDetailReducer+Impl.swift
@@ -91,6 +91,9 @@ extension GoalDetailReducer {
                 
                 // MARK: - Action
             case .bottomButtonTapped:
+                if state.currentCompletedGoal?.status == .completed {
+                    return .send(.showToast(.warning(message: "끝난 목표는 인증이 불가능해요!")))
+                }
                 let shouldGoToProofPhoto = (state.currentUser == .mySelf && !state.isCompleted) || state.isEditing
                 if shouldGoToProofPhoto {
                     return .run { send in

--- a/Projects/Feature/GoalDetail/Sources/Detail/GoalDetailReducer+Impl.swift
+++ b/Projects/Feature/GoalDetail/Sources/Detail/GoalDetailReducer+Impl.swift
@@ -49,6 +49,12 @@ private enum PokeCooldownManager {
         timestamps[String(goalId)] = Date().timeIntervalSince1970
         UserDefaults.standard.set(timestamps, forKey: userDefaultsKey)
     }
+
+    static func removePoke(goalId: Int64) {
+        var timestamps = UserDefaults.standard.dictionary(forKey: userDefaultsKey) as? [String: TimeInterval] ?? [:]
+        timestamps.removeValue(forKey: String(goalId))
+        UserDefaults.standard.set(timestamps, forKey: userDefaultsKey)
+    }
 }
 
 extension GoalDetailReducer {
@@ -107,12 +113,13 @@ extension GoalDetailReducer {
                     let timeText = PokeCooldownManager.formatRemainingTime(remaining)
                     return .send(.showToast(.warning(message: "\(timeText) 뒤에 다시 찌를 수 있어요")))
                 }
+                PokeCooldownManager.recordPoke(goalId: goalId)
                 return .run { send in
                     do {
                         try await goalClient.pokePartner(goalId)
-                        PokeCooldownManager.recordPoke(goalId: goalId)
                         await send(.showToast(.poke(message: "상대방을 찔렀어요!")))
                     } catch {
+                        PokeCooldownManager.removePoke(goalId: goalId)
                         await send(.showToast(.warning(message: "찌르기에 실패했어요")))
                     }
                 }

--- a/Projects/Feature/Home/Sources/Home/HomeReducer+Impl.swift
+++ b/Projects/Feature/Home/Sources/Home/HomeReducer+Impl.swift
@@ -61,6 +61,14 @@ private enum PokeCooldownManager {
         timestamps[String(goalId)] = Date().timeIntervalSince1970
         UserDefaults.standard.set(timestamps, forKey: userDefaultsKey)
     }
+
+    /// 찌르기 기록을 제거합니다. API 실패 시 쿨다운을 롤백합니다.
+    /// - Parameter goalId: 목표 ID
+    static func removePoke(goalId: Int64) {
+        var timestamps = UserDefaults.standard.dictionary(forKey: userDefaultsKey) as? [String: TimeInterval] ?? [:]
+        timestamps.removeValue(forKey: String(goalId))
+        UserDefaults.standard.set(timestamps, forKey: userDefaultsKey)
+    }
 }
 
 extension HomeReducer {
@@ -217,12 +225,14 @@ extension HomeReducer {
                         return .send(.showToast(.warning(message: "\(timeText) 뒤에 다시 찌를 수 있어요")))
                     }
                     // 상대방 미인증 시 찌르기 API 호출
+                    let goalId = card.id
+                    PokeCooldownManager.recordPoke(goalId: goalId)
                     return .run { send in
                         do {
-                            try await goalClient.pokePartner(card.id)
-                            PokeCooldownManager.recordPoke(goalId: card.id)
+                            try await goalClient.pokePartner(goalId)
                             await send(.showToast(.poke(message: "상대방을 찔렀어요!")))
                         } catch {
+                            PokeCooldownManager.removePoke(goalId: goalId)
                             await send(.showToast(.warning(message: "찌르기에 실패했어요")))
                         }
                     }

--- a/Projects/Feature/Home/Sources/Home/HomeReducer+Impl.swift
+++ b/Projects/Feature/Home/Sources/Home/HomeReducer+Impl.swift
@@ -18,6 +18,12 @@ import FeatureProofPhotoInterface
 import SharedDesignSystem
 import SharedUtil
 
+// MARK: - Cancel IDs
+
+private enum PokeCancelID: Hashable {
+    case poke(Int64)
+}
+
 // MARK: - Poke Cooldown Manager
 
 private enum PokeCooldownManager {
@@ -226,8 +232,8 @@ extension HomeReducer {
                     }
                     // 상대방 미인증 시 찌르기 API 호출
                     let goalId = card.id
-                    PokeCooldownManager.recordPoke(goalId: goalId)
                     return .run { send in
+                        PokeCooldownManager.recordPoke(goalId: goalId)
                         do {
                             try await goalClient.pokePartner(goalId)
                             await send(.showToast(.poke(message: "상대방을 찔렀어요!")))
@@ -236,6 +242,7 @@ extension HomeReducer {
                             await send(.showToast(.warning(message: "찌르기에 실패했어요")))
                         }
                     }
+                    .debounce(id: PokeCancelID.poke(goalId), for: .milliseconds(300), scheduler: DispatchQueue.main)
                 } else {
                     let verificationDate = TXCalendarUtil.apiDateString(for: state.calendarDate)
                     return .send(

--- a/Projects/Feature/Home/Sources/Home/HomeReducer+Impl.swift
+++ b/Projects/Feature/Home/Sources/Home/HomeReducer+Impl.swift
@@ -207,6 +207,10 @@ extension HomeReducer {
                 
             case let .yourCardTapped(card):
                 if !card.yourCard.isSelected {
+                    if let item = state.items.first(where: { $0.id == card.id }),
+                       case .completed = item.goal.status {
+                        return .send(.showToast(.warning(message: "끝난 목표는 인증이 불가능해요!")))
+                    }
                     // 쿨다운 확인 (3시간 이내 재요청 방지)
                     if let remaining = PokeCooldownManager.remainingCooldown(goalId: card.id) {
                         let timeText = PokeCooldownManager.formatRemainingTime(remaining)
@@ -224,7 +228,15 @@ extension HomeReducer {
                     }
                 } else {
                     let verificationDate = TXCalendarUtil.apiDateString(for: state.calendarDate)
-                    return .send(.delegate(.goToGoalDetail(id: card.id, owner: .you, verificationDate: verificationDate)))
+                    return .send(
+                        .delegate(
+                            .goToGoalDetail(
+                                id: card.id,
+                                owner: .you,
+                                verificationDate: verificationDate
+                            )
+                        )
+                    )
                 }
                 
             case let .myCardTapped(card):
@@ -424,7 +436,7 @@ extension HomeReducer {
                 
             case .deletePhotoLogFailed:
                 return .send(.showToast(.warning(message: "해제에 실패했어요")))
-                
+
             case let .fetchUnreadResponse(hasUnread):
                 state.hasUnreadNotification = hasUnread
                 return .none


### PR DESCRIPTION
<!--
PR 제목 작성 가이드: 
라벨명: 작업한 내용 요약
예: feat: 로그인 페이지 구현
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (자동으로 Close 처리됨) -->
- Close #271 


## 📙 작업 내역
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요(구현 내용 및 작업 내역을 기재합니다.) -->
- GoalDetail에서 종료된 케이스에서는 인증/찌르기를 불가능하게 변경
- 홈 화면에서, 과거 목표에서 찌르기 시도 시 클라이언트 단에서 거부하고 토스트를 띄우는 것으로 변경


## 🎨 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
|기능|미리보기|
|:--:|:--:|
| 기능 설명 |<img src="https://github.com/user-attachments/assets/3bad1f46-cbb2-4e70-96b3-bf11cac379f1" width="300" />|

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요. -->
- 찌르기 보다가 중복 요청 가능하길래 쿨다운 매니저 수정하고 디바운스 추가함