### PR TITLE
fix: 홈 화면의 시간 계산 오류 수정

### DIFF
--- a/Projects/Feature/Home/Interface/Sources/Home/HomeReducer.swift
+++ b/Projects/Feature/Home/Interface/Sources/Home/HomeReducer.swift
@@ -51,7 +51,7 @@ public struct HomeReducer {
         public var pendingDeletePhotologID: Int64?
         public var hasCards: Bool { !items.isEmpty }
         public var isEmptyVisible: Bool { !isLoading && items.isEmpty }
-        public let nowDate = CalendarNow()
+        public var nowDate: CalendarNow { CalendarNow() }
         public var toast: TXToastType?
         public var modal: TXModalStyle?
         public var isProofPhotoPresented: Bool = false

--- a/Projects/Shared/Util/Sources/CalendarNow.swift
+++ b/Projects/Shared/Util/Sources/CalendarNow.swift
@@ -15,7 +15,11 @@ public struct CalendarNow: Equatable, Hashable {
 
     public init(
         date: Date = Date(),
-        calendar: Calendar = Calendar(identifier: .gregorian)
+        calendar: Calendar = {
+            var c = Calendar(identifier: .gregorian)
+            c.timeZone = .current
+            return c
+        }()
     ) {
         self.year = calendar.component(.year, from: date)
         self.month = calendar.component(.month, from: date)


### PR DESCRIPTION
<!--
PR 제목 작성 가이드: 
라벨명: 작업한 내용 요약
예: feat: 로그인 페이지 구현
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (자동으로 Close 처리됨) -->
- Close #290 


## 📙 작업 내역
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요(구현 내용 및 작업 내역을 기재합니다.) -->
- HomeReducer에서 nowDate가 한 번만 평가되던 문제 수정
  - 사용 시점에서 평가하도록 수정, HomeReducer가 최초 생성된 이후 nowDate가 평가되어 고정되는 문제였음
- CalenderNow의 타임존 고정 (사실 별 이슈는 아니지만)