### PR TITLE
fix: 디데이 설정 화면에서의 흐름제어 변경

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -60,7 +60,7 @@ private let commonBuildSettings: SettingsDictionary = [
     "KAKAO_APP_KEY": "fb2997e54bfe080cc5c1d9706d1251f4",
     "GOOGLE_CLIENT_ID": "48737424560-adiebqu29lsflj85v9vrd4e4a3cp6sa3.apps.googleusercontent.com",
     "GOOGLE_REVERSED_CLIENT_ID": "com.googleusercontent.apps.48737424560-adiebqu29lsflj85v9vrd4e4a3cp6sa3",
-    "DEEPLINK_HOST": "keepiluv.jiyong.xyz",
+    "DEEPLINK_HOST": "keepiluv.teamtwix.com",
     "API_BASE_URL": "https://api.dev.teamtwix.com"
 ]
 

--- a/Projects/Feature/Onboarding/Sources/Dday/OnboardingDdayReducer.swift
+++ b/Projects/Feature/Onboarding/Sources/Dday/OnboardingDdayReducer.swift
@@ -32,6 +32,7 @@ public struct OnboardingDdayReducer {
         var showCalendarSheet: Bool = false
         var isLoading: Bool = false
         var toast: TXToastType?
+        var modal: TXModalStyle?
 
         public init() {
             self.selectedDate = TXCalendarDate()
@@ -52,6 +53,9 @@ public struct OnboardingDdayReducer {
 
         // MARK: - API Response
         case setAnniversaryResponse(Result<Void, Error>)
+
+        // MARK: - Modal
+        case modalConfirmTapped
 
         // MARK: - Delegate
         case delegate(Delegate)
@@ -100,13 +104,23 @@ public struct OnboardingDdayReducer {
 
             case let .setAnniversaryResponse(.failure(error)):
                 state.isLoading = false
-                // 이미 온보딩이 완료된 경우 (G4000), 성공과 동일하게 처리
                 if let onboardingError = error as? OnboardingError,
                    onboardingError == .alreadyOnboarded {
-                    return .send(.delegate(.ddayCompleted))
+                    state.modal = .info(
+                        image: .Icon.Illustration.heart,
+                        title: "메이트가 기념일을 등록했어요!",
+                        subtitle: "이미 우리의 기념일이 저장됐어요.\n이제 함께 시작해봐요 :)",
+                        leftButtonText: "확인",
+                        rightButtonText: "시작하기"
+                    )
+                    return .none
                 }
                 state.toast = .fit(message: "기념일 등록에 실패했어요. 다시 시도해주세요")
                 return .none
+
+            case .modalConfirmTapped:
+                state.modal = nil
+                return .send(.delegate(.ddayCompleted))
 
             case .delegate:
                 return .none

--- a/Projects/Feature/Onboarding/Sources/Dday/OnboardingDdayReducer.swift
+++ b/Projects/Feature/Onboarding/Sources/Dday/OnboardingDdayReducer.swift
@@ -25,6 +25,12 @@ import SharedDesignSystem
 public struct OnboardingDdayReducer {
     @Dependency(\.onboardingClient)
     private var onboardingClient
+    @Dependency(\.continuousClock)
+    private var clock
+
+    public enum CancelID: Hashable {
+        case polling
+    }
 
     @ObservableState
     public struct State: Equatable {
@@ -43,6 +49,9 @@ public struct OnboardingDdayReducer {
         // MARK: - Binding
         case binding(BindingAction<State>)
 
+        // MARK: - LifeCycle
+        case onAppear
+
         // MARK: - User Action
         case backButtonTapped
         case dateSelectorTapped
@@ -53,6 +62,10 @@ public struct OnboardingDdayReducer {
 
         // MARK: - API Response
         case setAnniversaryResponse(Result<Void, Error>)
+
+        // MARK: - Partner Polling
+        case pollingTick
+        case pollingResult(Result<OnboardingStatus, Error>)
 
         // MARK: - Modal
         case modalConfirmTapped
@@ -75,6 +88,14 @@ public struct OnboardingDdayReducer {
             case .binding:
                 return .none
 
+            case .onAppear:
+                return .run { [clock] send in
+                    for await _ in clock.timer(interval: .seconds(3)) {
+                        await send(.pollingTick)
+                    }
+                }
+                .cancellable(id: CancelID.polling, cancelInFlight: true)
+
             case .backButtonTapped:
                 return .send(.delegate(.navigateBack))
 
@@ -89,14 +110,17 @@ public struct OnboardingDdayReducer {
             case .completeButtonTapped:
                 guard let date = state.selectedDate.date, !state.isLoading else { return .none }
                 state.isLoading = true
-                return .run { send in
-                    do {
-                        try await onboardingClient.setAnniversary(date)
-                        await send(.setAnniversaryResponse(.success(())))
-                    } catch {
-                        await send(.setAnniversaryResponse(.failure(error)))
+                return .merge(
+                    .cancel(id: CancelID.polling),
+                    .run { send in
+                        do {
+                            try await onboardingClient.setAnniversary(date)
+                            await send(.setAnniversaryResponse(.success(())))
+                        } catch {
+                            await send(.setAnniversaryResponse(.failure(error)))
+                        }
                     }
-                }
+                )
 
             case .setAnniversaryResponse(.success):
                 state.isLoading = false
@@ -113,9 +137,33 @@ public struct OnboardingDdayReducer {
                         leftButtonText: "확인",
                         rightButtonText: "시작하기"
                     )
-                    return .none
+                    return .cancel(id: CancelID.polling)
                 }
                 state.toast = .fit(message: "기념일 등록에 실패했어요. 다시 시도해주세요")
+                return .none
+
+            case .pollingTick:
+                return .run { [onboardingClient] send in
+                    do {
+                        let status = try await onboardingClient.fetchStatus()
+                        await send(.pollingResult(.success(status)))
+                    } catch {
+                        await send(.pollingResult(.failure(error)))
+                    }
+                }
+
+            case let .pollingResult(.success(status)):
+                guard status == .completed else { return .none }
+                state.modal = .info(
+                    image: .Icon.Illustration.heart,
+                    title: "메이트가 기념일을 등록했어요!",
+                    subtitle: "이미 우리의 기념일이 저장됐어요.\n이제 함께 시작해봐요 :)",
+                    leftButtonText: "확인",
+                    rightButtonText: "시작하기"
+                )
+                return .cancel(id: CancelID.polling)
+
+            case .pollingResult(.failure):
                 return .none
 
             case .modalConfirmTapped:

--- a/Projects/Feature/Onboarding/Sources/Dday/OnboardingDdayView.swift
+++ b/Projects/Feature/Onboarding/Sources/Dday/OnboardingDdayView.swift
@@ -61,6 +61,9 @@ public struct OnboardingDdayView: View {
             )
         }
         .txLoading(isPresented: store.isLoading)
+        .txModal(item: $store.modal) { _ in
+            store.send(.modalConfirmTapped)
+        }
     }
 }
 

--- a/Projects/Feature/Onboarding/Sources/Dday/OnboardingDdayView.swift
+++ b/Projects/Feature/Onboarding/Sources/Dday/OnboardingDdayView.swift
@@ -60,6 +60,9 @@ public struct OnboardingDdayView: View {
                 }
             )
         }
+        .onAppear {
+            store.send(.onAppear)
+        }
         .txLoading(isPresented: store.isLoading)
         .txModal(item: $store.modal) { _ in
             store.send(.modalConfirmTapped)

--- a/Projects/Feature/Onboarding/Sources/OnboardingCoordinator.swift
+++ b/Projects/Feature/Onboarding/Sources/OnboardingCoordinator.swift
@@ -391,7 +391,7 @@ public struct OnboardingCoordinator {
             case .dday(.delegate(.navigateBack)):
                 popLastRoute(&state.routes)
                 state.dday = nil
-                return .none
+                return .cancel(id: OnboardingDdayReducer.CancelID.polling)
 
             case .dday(.delegate(.ddayCompleted)):
                 return .send(.startNotificationPermission)

--- a/Projects/Shared/DesignSystem/Sources/Components/Calendar/BottomSheet/TXCalendarBottomSheet.swift
+++ b/Projects/Shared/DesignSystem/Sources/Components/Calendar/BottomSheet/TXCalendarBottomSheet.swift
@@ -216,7 +216,7 @@ private extension TXCalendarBottomSheet {
     func datePickerView(height: CGFloat) -> some View {
         HStack(spacing: 0) {
             Picker("Year", selection: $selectedDate.year) {
-                ForEach(2026...2099, id: \.self) { year in
+                ForEach(1940...2099, id: \.self) { year in
                     Text(verbatim: "\(year)년").tag(year)
                 }
             }


### PR DESCRIPTION
<!--
PR 제목 작성 가이드: 
라벨명: 작업한 내용 요약
예: feat: 로그인 페이지 구현
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (자동으로 Close 처리됨) -->
- Close #289 


## 📙 작업 내역
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요(구현 내용 및 작업 내역을 기재합니다.) -->
- 자세한 히스토리는 https://teamtwixx.slack.com/archives/C0AKXBH3ECB/p1777120322477179
- 온보딩 디데이 입력 화면에서 상대가 먼저 디데이 등록을 마치는 경우 스킵하도록 변경

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요. -->
- 지금 서버에서 상대가 디데이 등록 마쳐도 온보딩 상태가 변경이 안되고 있는듯 그래서 동작 테스트가 안됨
- 추가로 초대장 주소 변경은 사소해서 온보딩 건드는 겸에 껴넣었음
