### PR TITLE
chore: Firebase 의존성을 SPM 미러 저장소로 변경

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -43,7 +43,6 @@ private let commonDependencies: [TargetDependency] = [
     .external(dependency: .KakaoSDKAuth),
     .external(dependency: .KakaoSDKCommon),
     .external(dependency: .GoogleSignIn),
-    .external(dependency: .FirebaseCore),
     .external(dependency: .FirebaseMessaging),
     .external(dependency: .FirebaseRemoteConfig),
     .core(implements: .crashlytics)

--- a/Projects/Domain/Auth/Project.swift
+++ b/Projects/Domain/Auth/Project.swift
@@ -23,8 +23,7 @@ let project = Project.makeModule(
                     .external(dependency: .KakaoSDKCommon),
                     .external(dependency: .KakaoSDKAuth),
                     .external(dependency: .KakaoSDKUser),
-                    .external(dependency: .GoogleSignIn),
-                    .external(dependency: .GoogleSignInSwift)
+                    .external(dependency: .GoogleSignIn)
                 ]
             )
         ),

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "5c0d0ed23de9ecd5ee8f58f55c05e9268ba72f94994e48c0f6f308e2b3d7430e",
+  "originHash" : "8c94e2269422c116e5525a199d307e9532a7fdf925bdb423193501f8bfe1d3fe",
   "pins" : [
-    {
-      "identity" : "abseil-cpp-binary",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/abseil-cpp-binary.git",
-      "state" : {
-        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
-        "version" : "1.2024072200.0"
-      }
-    },
     {
       "identity" : "alamofire",
       "kind" : "remoteSourceControl",
@@ -17,24 +8,6 @@
       "state" : {
         "revision" : "7be73f6c2b5cd90e40798b06ebd5da8f9f79cf88",
         "version" : "5.11.0"
-      }
-    },
-    {
-      "identity" : "app-check",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/app-check.git",
-      "state" : {
-        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
-        "version" : "11.2.0"
-      }
-    },
-    {
-      "identity" : "appauth-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/openid/AppAuth-iOS.git",
-      "state" : {
-        "revision" : "145104f5ea9d58ae21b60add007c33c1cc0c948e",
-        "version" : "2.0.0"
       }
     },
     {
@@ -47,93 +20,12 @@
       }
     },
     {
-      "identity" : "firebase-ios-sdk",
+      "identity" : "firebase-ios-sdk-xcframeworks",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "location" : "https://github.com/akaffenberger/firebase-ios-sdk-xcframeworks",
       "state" : {
-        "revision" : "d10045cace0b4c335c4efa8f7df7e9a9fc5a7c60",
+        "revision" : "7f17017dc1f529bab158eb950bd6012acd9e3ad1",
         "version" : "12.13.0"
-      }
-    },
-    {
-      "identity" : "google-ads-on-device-conversion-ios-sdk",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
-      "state" : {
-        "revision" : "19dffda9a9caf8d86570ff846535902d8509d7bf",
-        "version" : "3.5.0"
-      }
-    },
-    {
-      "identity" : "googleappmeasurement",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleAppMeasurement.git",
-      "state" : {
-        "revision" : "c2c76bebcfbb90d90ea10599f934f9af160e1604",
-        "version" : "12.13.0"
-      }
-    },
-    {
-      "identity" : "googledatatransport",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleDataTransport.git",
-      "state" : {
-        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
-        "version" : "10.1.0"
-      }
-    },
-    {
-      "identity" : "googlesignin-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleSignIn-iOS",
-      "state" : {
-        "revision" : "913b4005ea26aebe1c97d54e35ad82a515924c71",
-        "version" : "9.1.0"
-      }
-    },
-    {
-      "identity" : "googleutilities",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GoogleUtilities.git",
-      "state" : {
-        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
-        "version" : "8.1.0"
-      }
-    },
-    {
-      "identity" : "grpc-binary",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/grpc-binary.git",
-      "state" : {
-        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
-        "version" : "1.69.1"
-      }
-    },
-    {
-      "identity" : "gtm-session-fetcher",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/gtm-session-fetcher.git",
-      "state" : {
-        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
-        "version" : "3.5.0"
-      }
-    },
-    {
-      "identity" : "gtmappauth",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/GTMAppAuth.git",
-      "state" : {
-        "revision" : "56e0ccf09a6dd29dc7e68bdf729598240ca8aa16",
-        "version" : "5.0.0"
-      }
-    },
-    {
-      "identity" : "interop-ios-for-google-sdks",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
-      "state" : {
-        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
-        "version" : "101.0.0"
       }
     },
     {
@@ -152,33 +44,6 @@
       "state" : {
         "revision" : "d30a5fad881137e2267f96a8e3fc35c58999bb94",
         "version" : "8.6.2"
-      }
-    },
-    {
-      "identity" : "leveldb",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/leveldb.git",
-      "state" : {
-        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
-        "version" : "1.22.5"
-      }
-    },
-    {
-      "identity" : "nanopb",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/nanopb.git",
-      "state" : {
-        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
-        "version" : "2.30910.0"
-      }
-    },
-    {
-      "identity" : "promises",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/promises.git",
-      "state" : {
-        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
-        "version" : "2.4.0"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -9,13 +9,17 @@ import PackageDescription
             "ComposableArchitecture": .framework,
             "Kingfisher": .framework,
             "Pulse": .framework,
-            "KakaoSDK": .staticLibrary,
-            "GoogleSignIn": .staticLibrary,
-            "GoogleSignInSwift": .staticLibrary
+            "KakaoSDK": .staticLibrary
         ]
     )
 #endif
 
+// Firebase / GoogleSignIn은 akaffenberger 미러를 통해 prebuilt xcframework로 통합한다.
+// 미러는 Firebase 공식 zip을 SPM `binaryTarget`으로 재포장한 것으로, Firebase가
+// 의존하는 GoogleUtilities/Promises 등을 동일 패키지가 함께 제공하기 때문에
+// 다른 SPM 경로(예: google/GoogleSignIn-iOS의 transitive deps)와의 sub-framework
+// 분할 충돌을 구조적으로 피한다. 따라서 GoogleSignIn도 같은 미러의 product를 사용한다.
+// 버전은 미러의 release tag(= Firebase 공식 버전)와 일치한다.
 let package = Package(
     name: "Twix",
     dependencies: [
@@ -23,7 +27,6 @@ let package = Package(
         .package(url: "https://github.com/onevcat/Kingfisher", from: "8.0.0"),
         .package(url: "https://github.com/kean/Pulse", from: "5.1.4"),
         .package(url: "https://github.com/kakao/kakao-ios-sdk", from: "2.27.1"),
-        .package(url: "https://github.com/google/GoogleSignIn-iOS", from: "9.1.0"),
-        .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "12.13.0")
+        .package(url: "https://github.com/akaffenberger/firebase-ios-sdk-xcframeworks", from: "12.13.0")
     ]
 )

--- a/Tuist/ProjectDescriptionHelpers/Scripts/CrashlyticsScript.swift
+++ b/Tuist/ProjectDescriptionHelpers/Scripts/CrashlyticsScript.swift
@@ -21,9 +21,9 @@ public extension TargetScript {
             exit 0
         fi
 
-        UPLOAD_SYMBOLS="$SRCROOT/../../Tuist/.build/checkouts/firebase-ios-sdk/Crashlytics/upload-symbols"
+        UPLOAD_SYMBOLS="$SRCROOT/../../Tuist/.build/checkouts/firebase-ios-sdk-xcframeworks/Sources/FirebaseCrashlytics/upload-symbols"
         if [ ! -x "$UPLOAD_SYMBOLS" ]; then
-            UPLOAD_SYMBOLS=$(find "$SRCROOT/../.." -maxdepth 6 -name "upload-symbols" -path "*/firebase-ios-sdk/Crashlytics/*" 2>/dev/null | head -1)
+            UPLOAD_SYMBOLS=$(find "$SRCROOT/../.." -maxdepth 8 -name "upload-symbols" -path "*/FirebaseCrashlytics/*" 2>/dev/null | head -1)
         fi
         if [ -z "$UPLOAD_SYMBOLS" ] || [ ! -x "$UPLOAD_SYMBOLS" ]; then
             echo "warning: Firebase Crashlytics upload-symbols not found. Run 'tuist install'."

--- a/Tuist/ProjectDescriptionHelpers/Target/Dependency/TargetDependency+External.swift
+++ b/Tuist/ProjectDescriptionHelpers/Target/Dependency/TargetDependency+External.swift
@@ -16,14 +16,15 @@ public extension TargetDependency {
     /// 각 case는 SPM 패키지를 나타내며,
     /// `TargetDependency.external(dependency:)`와 유기적으로 사용됩니다.
     enum External: String {
+        // Firebase: akaffenberger 미러는 product 단위로 노출하며 FirebaseCore는
+        // 별도 product가 아닌 다른 Firebase product의 transitive 의존성으로 포함된다.
+        // 따라서 FirebaseCore는 enum에 두지 않는다.
         case FirebaseAnalytics
-        case FirebaseCore
         case FirebaseMessaging
         case FirebaseRemoteConfig
         case FirebaseCrashlytics
-        
+
         case GoogleSignIn
-        case GoogleSignInSwift
 
         case KakaoSDKCommon
         case KakaoSDKAuth


### PR DESCRIPTION
<!--
PR 제목 작성 가이드: 
라벨명: 작업한 내용 요약
예: feat: 로그인 페이지 구현
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (자동으로 Close 처리됨) -->
- Close #302


## 📙 작업 내역
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요(구현 내용 및 작업 내역을 기재합니다.) -->
- Firebase를 Google 공식 레포지토리에서 미러 레포지토리로 변경
  - https://github.com/akaffenberger/firebase-ios-sdk-xcframeworks
- 자세한 내역은 아래에


## 빌드 타임 측정 결과
### 측정 조건

- **Hardware**: macOS Darwin 25.2.0, Apple Silicon (arm64)
- **Target**: TwixDebug / Debug / iPhone 17 (iOS 26.2) simulator, `ONLY_ACTIVE_ARCH=YES`
- **Cold 빌드 기준**
  - `~/Library/Developer/Xcode/DerivedData/Twix-*` 삭제
  - `tuist clean` 실행
  - SPM checkouts까지 제거 후 측정
- 두 시나리오 모두 **Tuist binary cache 비활성화 상태**
  - 기존 `#300` commit과 동일 조건

---

## Cold 빌드 사이클

_clone 직후 시나리오_
| 단계 | Source SPM | akaffenberger 미러 | 차이 |
|---|---:|---:|---:|
| `tuist install` | 30.34s | 20.58s | -9.76s (-32%) |
| `tuist generate` | 9.49s | 8.61s | -0.88s (-9%) |
| `xcodebuild build` | 123.95s | 107.68s | -16.27s (-13%) |
| **합계** | **163.78s** | **136.87s** | **-26.91s (-16%)** |

---

## SPM 미러 vs 원본 Firebase SDK

### 핵심

- **동작/API는 동일**
  - 둘 다 `import FirebaseAnalytics` 등 기존 코드 그대로 사용 가능
  - 미러도 Firebase 공식 release `xcframework`를 사용

- **차이는 배포 방식**
  - 원본: Firebase 및 의존성을 **소스에서 직접 컴파일**
  - 미러: 이미 빌드된 **prebuilt xcframework를 다운로드 후 추출**

### 차이점

| 항목 | 원본 Firebase SDK | 미러 |
|---|---|---|
| 형태 | 소스 패키지 | Binary package |
| 빌드 | 로컬 컴파일 필요 | 컴파일 없음 |
| 의존성 | GoogleUtilities 등 여러 SPM 의존성 | 외부 SPM 의존성 거의 없음 |
| Tuist 그래프 | 노드 많음 | 평탄함 |
| 속도 | 느림 | 빠름 |
| 신뢰성 | Google 공식 | 비공식 미러 + checksum 검증 |
| 릴리즈 반영 | 즉시 | 약간 지연 가능 |