### PR TITLE
feat: 알림 눌렀을 때 인증샷 빈화면 버그 수정

### DIFF
--- a/Projects/Feature/GoalDetail/Interface/Sources/GoalDetailReducer.swift
+++ b/Projects/Feature/GoalDetail/Interface/Sources/GoalDetailReducer.swift
@@ -90,7 +90,10 @@ public struct GoalDetailReducer {
         public var isCameraPermissionAlertPresented: Bool = false
         
         public var selectedReactionEmoji: ReactionEmoji?
-        public var myHasEmoji: Bool { isFrontMyCard && selectedReactionEmoji != nil }
+        public var didPlayMyEmojiAppearAnimation: Bool = false
+        public var shouldShowMyEmojiAnimation: Bool {
+            isFrontMyCard && selectedReactionEmoji != nil && !didPlayMyEmojiAppearAnimation
+        }
         public var isShowReactionBar: Bool { !isFrontMyCard && isCompleted }
         public var isLoading: Bool { item == nil }
         public var isFetchFailed: Bool = false
@@ -142,6 +145,7 @@ public struct GoalDetailReducer {
             case navigationBarTapped(TXNavigationBar.Action)
             case reactionEmojiTapped(ReactionEmoji)
             case cardSwiped
+            case myEmojiAppearAnimationPlayed
             case focusChanged(Bool)
             case dimmedBackgroundTapped
             case proofPhotoDismissed

--- a/Projects/Feature/GoalDetail/Sources/Detail/GoalDetailReducer+Impl.swift
+++ b/Projects/Feature/GoalDetail/Sources/Detail/GoalDetailReducer+Impl.swift
@@ -194,6 +194,10 @@ extension GoalDetailReducer {
                 state.createdAt = timeFormatter.displayText(from: state.currentCard?.createdAt)
                 
                 return .none
+
+            case .view(.myEmojiAppearAnimationPlayed):
+                state.didPlayMyEmojiAppearAnimation = true
+                return .none
                 
             case let .view(.focusChanged(isFocused)):
                 state.isCommentFocused = isFocused

--- a/Projects/Feature/GoalDetail/Sources/Detail/GoalDetailView.swift
+++ b/Projects/Feature/GoalDetail/Sources/Detail/GoalDetailView.swift
@@ -109,7 +109,7 @@ public struct GoalDetailView: View {
             myEmojiFlyingReactionOverlay
         }
         .txToast(item: $store.toast, customPadding: 54)
-        .txLoading(isPresented: store.isSavingPhotoLog)
+        .txLoading(isPresented: store.isLoading || store.isSavingPhotoLog)
     }
 }
 

--- a/Projects/Feature/GoalDetail/Sources/Detail/GoalDetailView.swift
+++ b/Projects/Feature/GoalDetail/Sources/Detail/GoalDetailView.swift
@@ -37,7 +37,6 @@ public struct GoalDetailView: View {
     @State private var rectFrame: CGRect = .zero
     @State private var keyboardFrame: CGRect = .zero
     @StateObject private var myEmojiFlyingReactionEmitter = FlyingReactionEmitter()
-    @State private var didPlayMyEmojiAppearAnimation = false
     @State private var cardOffset: CGFloat = .zero
     @State private var isCrossingDuringDrag: Bool = false
     
@@ -85,7 +84,6 @@ public struct GoalDetailView: View {
             store.send(.view(.onAppear))
         }
         .onDisappear {
-            didPlayMyEmojiAppearAnimation = false
             myEmojiFlyingReactionEmitter.clear()
             store.send(.view(.onDisappear))
         }
@@ -538,10 +536,8 @@ private extension GoalDetailView {
         containerWidth: CGFloat,
         containerHeight: CGFloat
     ) {
-        guard store.myHasEmoji,
-              !didPlayMyEmojiAppearAnimation,
+        guard store.shouldShowMyEmojiAnimation,
               let selectedEmoji = store.selectedReactionEmoji else { return }
-        didPlayMyEmojiAppearAnimation = true
         myEmojiFlyingReactionEmitter.emit(
             emoji: selectedEmoji,
             config: .goalDetailBottom(
@@ -549,6 +545,7 @@ private extension GoalDetailView {
                 height: containerHeight
             )
         )
+        store.send(.view(.myEmojiAppearAnimationPlayed))
     }
 }
 

--- a/Projects/Feature/GoalDetail/Sources/Detail/GoalDetailView.swift
+++ b/Projects/Feature/GoalDetail/Sources/Detail/GoalDetailView.swift
@@ -73,6 +73,10 @@ public struct GoalDetailView: View {
                 if shouldShowCommentOverlay {
                     floatingCommentOverlay
                 }
+
+                if store.isShowReactionBar {
+                    reactionBar
+                }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         }
@@ -258,12 +262,6 @@ private extension GoalDetailView {
                 .padding(.top, 14)
                 .padding(.trailing, 36)
         }
-        
-        if store.isShowReactionBar {
-            reactionBar
-                .padding(.top, Constants.emojiTopPadding)
-                .padding(.horizontal, 20)
-        }
     }
     
     var createdAtText: some View {
@@ -279,6 +277,13 @@ private extension GoalDetailView {
             onSelect: { emoji in
                 store.send(.view(.reactionEmojiTapped(emoji)))
             }
+        )
+        .padding(.horizontal, Constants.reactionBarHorizontalPadding)
+        .position(
+            x: rectFrame.midX,
+            y: rectFrame.maxY
+                + Constants.reactionBarTopPadding
+                + Constants.reactionBarHeight / 2
         )
     }
     
@@ -612,7 +617,9 @@ private extension GoalDetailView {
         static let minimumDragResistance: CGFloat = 0.35
         static var cardTopPadding: CGFloat { isSEDevice ? 34 : 89 }
         static var cardSize: CGFloat { isSEDevice ? 321 : 336 }
-        static var emojiTopPadding: CGFloat { isSEDevice ? 19 : 69 }
+        static let reactionBarHeight: CGFloat = 77
+        static let reactionBarHorizontalPadding: CGFloat = 20
+        static var reactionBarTopPadding: CGFloat { isSEDevice ? 19 : 69 }
     }
 }
 

--- a/Projects/Feature/Home/Sources/Root/HomeCoordinator+Impl.swift
+++ b/Projects/Feature/Home/Sources/Root/HomeCoordinator+Impl.swift
@@ -29,14 +29,14 @@ extension HomeCoordinator {
         // swiftlint:disable:next closure_body_length
         let reducer = Reduce<State, Action> { state, action in
             switch action {
-            case let .home(.delegate(.goToGoalDetail(id, owner, verificationDate))):
-                state.routes.append(.detail)
-                state.goalDetail = .init(
-                    currentUser: owner,
-                    id: id,
-                    verificationDate: verificationDate
+            case let .home(.delegate(.goToGoalDetail(id, owner, date))):
+                return .send(
+                    .navigateToGoalDetail(
+                        id: id,
+                        owner: owner,
+                        date: date
+                    )
                 )
-                return .none
                 
             case let .home(.delegate(.goToMakeGoal(category))):
                 state.routes.append(.makeGoal)
@@ -186,12 +186,13 @@ extension HomeCoordinator {
                 
             case let .navigateToGoalDetail(id, owner, date):
                 state.routes.append(.detail)
+                let shouldFetchGoalDetail = state.goalDetail != nil
                 state.goalDetail = .init(
                     currentUser: owner,
                     id: id,
                     verificationDate: date
                 )
-                return .none
+                return shouldFetchGoalDetail ? .send(.goalDetail(.view(.onAppear))) : .none
 
             case .delegate:
                 return .none

--- a/Projects/Feature/Home/Sources/Root/HomeCoordinator+Impl.swift
+++ b/Projects/Feature/Home/Sources/Root/HomeCoordinator+Impl.swift
@@ -185,14 +185,20 @@ extension HomeCoordinator {
                 return .none
                 
             case let .navigateToGoalDetail(id, owner, date):
-                state.routes.append(.detail)
-                let shouldFetchGoalDetail = state.goalDetail != nil
+                let isAlreadyOnDetail = state.routes.last == .detail
+
+                if !isAlreadyOnDetail {
+                    state.routes.append(.detail)
+                }
+
                 state.goalDetail = .init(
                     currentUser: owner,
                     id: id,
                     verificationDate: date
                 )
-                return shouldFetchGoalDetail ? .send(.goalDetail(.view(.onAppear))) : .none
+                return isAlreadyOnDetail
+                    ? .send(.goalDetail(.view(.onAppear)))
+                    : .none
 
             case .delegate:
                 return .none


### PR DESCRIPTION
<!--
PR 제목 작성 가이드: 
라벨명: 작업한 내용 요약
예: feat: 로그인 페이지 구현
-->

## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (자동으로 Close 처리됨) -->
- Close #352 


## 📙 작업 내역
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요(구현 내용 및 작업 내역을 기재합니다.) -->
- 인증샷 상세 onAppear될 때 data fetch했었는데 해당 화면에서 알림 누르면 onAppear가 동작 안해 dataFetch를 안해서 흰 화면이 떠서 푸시알림 눌러서 진입했을 경우 onAppear 액션 호출하도록 수정
- 상대카드 이모지 애니메이션이 코멘트 뒤로가서 앞으로 가도록 수정
- 인증샷 상세 로딩 인디케이터처리 안되있던거 수정 


## 🎨 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
https://github.com/user-attachments/assets/ab111321-af4c-49fa-a3cd-1b9372dbc28b

